### PR TITLE
update shinyparticles to particlesjs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
 	shinyjqui,
 	graphTweets,
 	shinythemes,
-	shinyparticles,
+	particlesjs,
 	shinycustomloader
 Remotes: 
 	JohnCoene/aforce,
@@ -39,4 +39,4 @@ Remotes:
 	JohnCoene/aframer,
 	JohnCoene/reactrend,
 	JohnCoene/graphTweets,
-	dreamRs/shinyparticles
+	dreamRs/particlesjs

--- a/R/03-chirp.R
+++ b/R/03-chirp.R
@@ -283,7 +283,7 @@ chirp <- function(){
             h3("Twitter Network Explorer.", class = "center")
           )
         ),
-        shinyparticles::particles(particles_json, target_id = "particles-target", element_id = "particles"),
+        particlesjs::particles(particles_json, target_id = "particles-target", element_id = "particles"),
         tabsetPanel(
           type = "tabs",
           tabPanel(


### PR DESCRIPTION
Hey, it looks like the `shinyparticles` package was renamed to `particlesjs`, which caused an error when trying to install `chirp`. 

Awesome package btw! Really cool stuff.